### PR TITLE
bugfix: correct initialization of index to find the nearest pairs

### DIFF
--- a/goes2mpas/main.F90
+++ b/goes2mpas/main.F90
@@ -229,7 +229,7 @@ program  main
    ! find a SINGLE nearest point from a set of matching pairs.
    do iC= 1, nC
       dist_min=999. ! init
-      idx_min=999   ! init
+      idx_min=-999  ! init
       do iS = 1, cnt_match(iC)
          ! measure a distance between Satellite point and MPAS point,
          ! then, find closest pair
@@ -240,7 +240,7 @@ program  main
          end if
       end do
       ! assign
-      if (idx_min.ne.999) then
+      if (idx_min.ne.-999) then
          field_mpas(iC,1:nfield) = field_s_dist(idx_min,1:nfield,iC)
       end if
    end do !-- nC


### PR DESCRIPTION
### Description
`idx_min` is used to find the nearest pairs. This was initialized with `999` value before. However, actual 999th index (of surrounding ABI pixels) can be the nearest pair for a given MPAS cell, then this leads to assign a missing value for a given cell. This has happened for 120 km MPAS mesh. This PR replaces the `999` value by `-999` for `idx_min` initialization.

### Before bug fix
![Screen Shot 2023-03-02 at 9 34 51 AM](https://user-images.githubusercontent.com/33296274/222497419-d7d7e520-3a25-452d-85a4-9912be4f6294.png)

### After bug fix
![Screen Shot 2023-03-02 at 9 35 15 AM](https://user-images.githubusercontent.com/33296274/222497437-eb76da93-69f2-47a8-af02-d62b609eb9b4.png)


### LIST OF MODIFIED FILES:
M       goes2mpas/main.F90
