### PR TITLE
bugfix on the conditional for regional domain

### DIFF
--- a/goes2mpas/main.F90
+++ b/goes2mpas/main.F90
@@ -166,7 +166,7 @@ program  main
    ! buid kd-tree
    nn=1  ! number of nearest points !BJJ set "1". No need to be "3"
    allocate (interp_indx(nn, nS_valid))
-   interp_indx=-999.0 !init
+   interp_indx=-999 !init
    ageometry = atlas_geometry("UnitSphere")
    kd = atlas_indexkdtree(ageometry)
    call kd%reserve(nC)
@@ -212,9 +212,9 @@ program  main
 
          !for regional model domain, skip if bdymask=6 or 7
          if( allocated(bdymask_mpas) .and. &
-            ix .eq. -999.0        .or.  &       ! this condition will not meet
-            bdymask_mpas(ix).eq.6 .or.  &
-            bdymask_mpas(ix).eq.7       ) cycle ! regional model domain
+            ix .eq. -999          .or.  &       ! this condition will not meet
+            bdymask_mpas(ix).eq.6 .or.  &       ! bdy of regional model domain
+            bdymask_mpas(ix).eq.7       ) cycle ! bdy of regional model domain
 
          cnt_match(ix)=cnt_match(ix)+1
       end do
@@ -251,10 +251,8 @@ program  main
    do iS = 1, nS_valid
       ix=interp_indx(1,iS)
       !for regional model domain, skip if bdymask=6 or 7 or out of min/max of lat/lon
-      if( allocated(bdymask_mpas) .and. &
-         ix .eq. -999.0        .or.  &       ! this condition will not meet
-         bdymask_mpas(ix).eq.6 .or.  &
-         bdymask_mpas(ix).eq.7       ) cycle ! regional model domain
+      if( allocated(bdymask_mpas) .and. ix .eq. -999 )       cycle !this condition can be met
+      if( bdymask_mpas(ix).eq.6 .or. bdymask_mpas(ix).eq.7 ) cycle !bdy of regional model domain
       cnt_match(ix)=cnt_match(ix)+1
       lon_s_dist(cnt_match(ix),ix)=lon_s_valid(iS)*deg2rad  !pass as [radian] to make the next step [dist] easier.
       lat_s_dist(cnt_match(ix),ix)=lat_s_valid(iS)*deg2rad

--- a/goes2mpas/main.F90
+++ b/goes2mpas/main.F90
@@ -33,7 +33,9 @@ program  main
    !mpas lat/lon and interpolated field
    integer :: nC, iC  ! nC: total number of MPAS grid
    real(sp), allocatable :: lon_mpas(:), lat_mpas(:)       ! to read. depend on the NetCDF file.
+   real(sp), allocatable :: bdymask_mpas(:)                ! optional for regional mpas domain
    real(dp), allocatable :: lon_mpas_dp(:), lat_mpas_dp(:) ! double precision for kd-tree
+   real(dp)  :: lon_min, lon_max, lat_min, lat_max         ! for regional model domain
    real(sp), allocatable :: field_mpas(:,:)                ! interpolated field_s (nC,nfield)
    real(sp), allocatable :: field_mpas_std(:,:)            ! For SO, std info     (nC,nfield)
 
@@ -142,7 +144,7 @@ program  main
 
    !----- 2. read MPAS lat/lon --------------------------------------------------
    ! read lon / lat from MPAS file
-   call read_mpas_latlon (f_mpas_latlon, nC, lon_mpas, lat_mpas)  ! unit [radian], single precision
+   call read_mpas_latlon (f_mpas_latlon, nC, lon_mpas, lat_mpas, bdymask_mpas)  ! unit [radian], single precision
    lon_mpas_dp=lon_mpas ! pass double precision for kd-tree
    lat_mpas_dp=lat_mpas
    do iC=1,nC
@@ -150,11 +152,21 @@ program  main
       if(lon_mpas_dp(iC).gt.pi) lon_mpas_dp(iC)=lon_mpas_dp(iC)-2.d0*pi
    end do
 
+   if( allocated(bdymask_mpas) ) then ! regional mpas domain
+      lon_min = minval(lon_mpas_dp) * rad2deg
+      lon_max = maxval(lon_mpas_dp) * rad2deg
+      lat_min = minval(lat_mpas_dp) * rad2deg
+      lat_max = maxval(lat_mpas_dp) * rad2deg
+      write(*,*) "BJJ: This is regional domain: lon_min, lon_max, lat_min, lat_max=",&
+         lon_min, lon_max, lat_min, lat_max
+   end if
+
 
    !----- 3. build and search kd-tree -------------------------------------------
    ! buid kd-tree
    nn=1  ! number of nearest points !BJJ set "1". No need to be "3"
    allocate (interp_indx(nn, nS_valid))
+   interp_indx=-999.0 !init
    ageometry = atlas_geometry("UnitSphere")
    kd = atlas_indexkdtree(ageometry)
    call kd%reserve(nC)
@@ -173,6 +185,13 @@ program  main
       call date_and_time(VALUES=tval)
       write (6, 777) 'kd%closestPoints start',tval(1),'-',tval(2),'-',tval(3),tval(5),':',tval(6),':',tval(7)
       do iS=1, nS_valid
+         !quick decision for regional model domain: out of min/max of lon/lat
+         if( allocated(bdymask_mpas) .and.     &
+             lon_s_valid(iS) .lt. lon_min .or. &
+             lon_s_valid(iS) .gt. lon_max .or. &
+             lat_s_valid(iS) .lt. lat_min .or. &
+             lat_s_valid(iS) .gt. lat_max        ) cycle
+
          ! get nn index
          call kd%closestPoints(lon_s_valid(iS)*deg2rad, lat_s_valid(iS)*deg2rad, &  !need a unit of [radian]
                                nn, interp_indx(:,iS))
@@ -190,6 +209,13 @@ program  main
 
          !count # of matching. NOTE: this also works even when nn is not "1".
          ix=interp_indx(1,iS)
+
+         !for regional model domain, skip if bdymask=6 or 7
+         if( allocated(bdymask_mpas) .and. &
+            ix .eq. -999.0        .or.  &       ! this condition will not meet
+            bdymask_mpas(ix).eq.6 .or.  &
+            bdymask_mpas(ix).eq.7       ) cycle ! regional model domain
+
          cnt_match(ix)=cnt_match(ix)+1
       end do
       call date_and_time(VALUES=tval)
@@ -224,6 +250,11 @@ program  main
 
    do iS = 1, nS_valid
       ix=interp_indx(1,iS)
+      !for regional model domain, skip if bdymask=6 or 7 or out of min/max of lat/lon
+      if( allocated(bdymask_mpas) .and. &
+         ix .eq. -999.0        .or.  &       ! this condition will not meet
+         bdymask_mpas(ix).eq.6 .or.  &
+         bdymask_mpas(ix).eq.7       ) cycle ! regional model domain
       cnt_match(ix)=cnt_match(ix)+1
       lon_s_dist(cnt_match(ix),ix)=lon_s_valid(iS)*deg2rad  !pass as [radian] to make the next step [dist] easier.
       lat_s_dist(cnt_match(ix),ix)=lat_s_valid(iS)*deg2rad

--- a/goes2mpas/main.F90
+++ b/goes2mpas/main.F90
@@ -38,6 +38,7 @@ program  main
    real(dp)  :: lon_min, lon_max, lat_min, lat_max         ! for regional model domain
    real(sp), allocatable :: field_mpas(:,:)                ! interpolated field_s (nC,nfield)
    real(sp), allocatable :: field_mpas_std(:,:)            ! For SO, std info     (nC,nfield)
+   logical :: l_regional_domain = .false.                  ! flag for regional mpas domain, initialized as .false.
 
    !kd-tree
    type(atlas_indexkdtree) :: kd
@@ -152,7 +153,8 @@ program  main
       if(lon_mpas_dp(iC).gt.pi) lon_mpas_dp(iC)=lon_mpas_dp(iC)-2.d0*pi
    end do
 
-   if( allocated(bdymask_mpas) ) then ! regional mpas domain
+   if( allocated(bdymask_mpas) ) l_regional_domain = .true.
+   if( l_regional_domain ) then ! regional mpas domain
       lon_min = minval(lon_mpas_dp) * rad2deg
       lon_max = maxval(lon_mpas_dp) * rad2deg
       lat_min = minval(lat_mpas_dp) * rad2deg
@@ -186,11 +188,12 @@ program  main
       write (6, 777) 'kd%closestPoints start',tval(1),'-',tval(2),'-',tval(3),tval(5),':',tval(6),':',tval(7)
       do iS=1, nS_valid
          !quick decision for regional model domain: out of min/max of lon/lat
-         if( allocated(bdymask_mpas) .and.     &
-             lon_s_valid(iS) .lt. lon_min .or. &
-             lon_s_valid(iS) .gt. lon_max .or. &
-             lat_s_valid(iS) .lt. lat_min .or. &
-             lat_s_valid(iS) .gt. lat_max        ) cycle
+         if( l_regional_domain ) then
+            if(  lon_s_valid(iS) .lt. lon_min .or. &
+                 lon_s_valid(iS) .gt. lon_max .or. &
+                 lat_s_valid(iS) .lt. lat_min .or. &
+                 lat_s_valid(iS) .gt. lat_max        ) cycle
+         end if
 
          ! get nn index
          call kd%closestPoints(lon_s_valid(iS)*deg2rad, lat_s_valid(iS)*deg2rad, &  !need a unit of [radian]
@@ -211,10 +214,11 @@ program  main
          ix=interp_indx(1,iS)
 
          !for regional model domain, skip if bdymask=6 or 7
-         if( allocated(bdymask_mpas) .and. &
-            ix .eq. -999          .or.  &       ! this condition will not meet
-            bdymask_mpas(ix).eq.6 .or.  &       ! bdy of regional model domain
-            bdymask_mpas(ix).eq.7       ) cycle ! bdy of regional model domain
+         if( l_regional_domain) then
+            if( ix .eq. -999          .or.  &       ! this condition will not meet
+                bdymask_mpas(ix).eq.6 .or.  &       ! bdy of regional model domain
+                bdymask_mpas(ix).eq.7       ) cycle ! bdy of regional model domain
+         end if
 
          cnt_match(ix)=cnt_match(ix)+1
       end do
@@ -251,8 +255,10 @@ program  main
    do iS = 1, nS_valid
       ix=interp_indx(1,iS)
       !for regional model domain, skip if bdymask=6 or 7 or out of min/max of lat/lon
-      if( allocated(bdymask_mpas) .and. ix .eq. -999 )       cycle !this condition can be met
-      if( bdymask_mpas(ix).eq.6 .or. bdymask_mpas(ix).eq.7 ) cycle !bdy of regional model domain
+      if( l_regional_domain ) then
+         if( ix .eq. -999 ) cycle !this condition can be met.
+         if( bdymask_mpas(ix).eq.6 .or. bdymask_mpas(ix).eq.7 ) cycle !bdy of regional model domain
+      end if
       cnt_match(ix)=cnt_match(ix)+1
       lon_s_dist(cnt_match(ix),ix)=lon_s_valid(iS)*deg2rad  !pass as [radian] to make the next step [dist] easier.
       lat_s_dist(cnt_match(ix),ix)=lat_s_valid(iS)*deg2rad

--- a/goes2mpas/read_write_mpas_mod.F90
+++ b/goes2mpas/read_write_mpas_mod.F90
@@ -7,12 +7,13 @@ module  mod_read_write_mpas
 
    contains
 
-   subroutine read_mpas_latlon (fname, nC, lon, lat)
+   subroutine read_mpas_latlon (fname, nC, lon, lat, bdymask)
 
    implicit none
-   character(len=256),        intent( in) :: fname
-   integer(i_kind),           intent(out) :: nC
-   real(r_kind), allocatable, intent(out) :: lon(:), lat(:) 
+   character(len=256),                  intent( in) :: fname
+   integer(i_kind),                     intent(out) :: nC
+   real(r_kind), allocatable,           intent(out) :: lon(:), lat(:) 
+   real(r_kind), allocatable, optional, intent(out) :: bdymask(:)
    ! loc
    integer(i_kind) :: ncid, nf_status, dimid, varid
    logical :: isfile
@@ -40,6 +41,12 @@ module  mod_read_write_mpas
    nf_status = nf90_GET_VAR(ncid, varid, lon(:))
    nf_status = nf90_INQ_VARID(ncid, 'latCell', varid)
    nf_status = nf90_GET_VAR(ncid, varid, lat(:))
+   !optionally read 'bdyMaskCell' for regional model domain
+   nf_status = nf90_INQ_VARID(ncid, 'bdyMaskCell', varid)
+   if ( nf_status == 0 ) then
+      allocate( bdymask(nC) )
+      nf_status = nf90_GET_VAR(ncid, varid, bdymask(:))
+   end if
 
    nf_status = nf90_CLOSE(ncid)
 


### PR DESCRIPTION
### Description
* This PR fixes the bug introduced from  previous PR #10.
* Newly-added conditional for regional domain made trouble for global domain. This is because `bdymask_mpas` is not available from global domain. So the conditional statements were revised here by using new logical variable `l_regional_domain`.

### LIST OF MODIFIED FILES
M       goes2mpas/main.F90
