### PR TITLE
Set a different value for "clear" pixels to distinguish them from other missing values in the Cloud Top Pressure product

### DIFF
--- a/goes2mpas/goes_abi_mod.F90
+++ b/goes2mpas/goes_abi_mod.F90
@@ -1116,6 +1116,9 @@ subroutine read_L2_PRES(ncid, nx, ny, ctp, time_start)
                end if
             end if
          end if
+         if ( itmp_short_2d(i,j) == ifill .and. qf(i,j) == 4 ) then !invalid_due_to_clear_or_probably_clear_sky_qf
+            ctp(i,j) = -777.
+         end if
       end do
    end do
    !write(*,*) "min/max of ctp =", minval(ctp), maxval(ctp)

--- a/goes2mpas/main.F90
+++ b/goes2mpas/main.F90
@@ -17,7 +17,7 @@ program  main
    implicit none
 
    ! local
-   integer :: i, j, icnt, istat
+   integer :: i, j, icnt, icnt2, istat
    integer :: nml_unit = 81
 
    integer :: nx, ny, nfield, ifld  ! x y dimension of raw satellite data, number of field read from satellite
@@ -290,14 +290,16 @@ program  main
                cycle !do nothing
             else
                ! do superob
-               icnt=count(field_s_dist(:,ifld,iC)/=-999.0) ! check the # of valid data
+               icnt=count(field_s_dist(:,ifld,iC)/=-999.0 .and. field_s_dist(:,ifld,iC)/=-777.0) ! check the # of valid data
+               icnt2=count(field_s_dist(:,ifld,iC)==-777.0)
+               if(icnt.eq.0 .and. icnt2.ne.0) field_mpas(iC,ifld) = -777.0 ! special treatment for clear CTP
                if(icnt.eq.0) cycle !do nothing
                if(icnt.gt.cnt_match(iC)) STOP 778 ! sanity check
                !if(icnt.ne cnt_match(iC)) write(*,*) "=========== WARNING ========== &
                !                          There are some missing values in paired- obs pixels", ifld, iC, icnt, cnt_match(iC)
                ! temporary array W/O any missing data
                allocate( array_so(icnt) )
-               array_so=pack(field_s_dist(:,ifld,iC), field_s_dist(:,ifld,iC)/=-999.0)
+               array_so=pack(field_s_dist(:,ifld,iC), field_s_dist(:,ifld,iC)/=-999.0 .and. field_s_dist(:,ifld,iC)/=-777.0)
                ! calculate mean
                field_mpas(iC,ifld) = sum(array_so(1:icnt)) / real(icnt) ! applied for both cloud mask and other physical quantities
                ! calculate std 


### PR DESCRIPTION
### Description
* This PR adds a "clear" information from the Cloud Top Pressure product, which will be used in the cloud layering verification.
* From `OR_ABI-L2-CTPF` NetCDF file, the variable `DQF` contains the information on the clear pixel (flag `4`).
 * When the data is ingested, specify a `-777.0` value for quality flags with `4` (invalid_due_to_clear_or_probably_clear_sky_qf). Note that usual missing points are filled with a `-999.9` value.
 * Add some logic in SO. No change is needed for the nearest neighbor method.
 * Potentially, same procedure can be done for other L2 cloud products, such as cloud top temperature, cloud top height, cloud top phase, if needed.

### ISSUE
Fixes #14

### LIST OF MODIFIED FILES
M       goes2mpas/goes_abi_mod.F90
M       goes2mpas/main.F90